### PR TITLE
 removing testing data links from public dataset documentation

### DIFF
--- a/docs/source/datasets.md
+++ b/docs/source/datasets.md
@@ -4,8 +4,5 @@ This page lists all versioned datasets managed by the OEO Data Management tool,
 
 | Dataset Name | Version | Timestamp (UTC) | Description | Download |
 |--------------|---------|-----------------|-------------|----------|
-| test_database.sqlite | v4 | 2025-07-25T16:13:20.872123 | testing the autogenerating data docs script | [Download](https://data.openenergyoutlook.org/test_database/v4-6d60f0035a80de92c3f3df433212699e0584a09a7d4943693ae0889d98640641.sqlite) |
-| test_database.sqlite | v3 | 2025-07-19T15:09:30.356015 | testing sql diffing with summary | [Download](https://data.openenergyoutlook.org/test_database/v3-6c37e0744a6f49f8b3e5b24b74080c2ae845b925633ccefa81193201639bee12.sqlite) |
-| test_database.sqlite | v2 | 2025-07-08T21:11:37.340350 | updating test_database to get multiple versions | [Download](https://data.openenergyoutlook.org/test_database/v2-e287b00772296e3ae8d65699570662ff316d8dae50deef4041fde65ca73202a5.sqlite) |
 | usp_26z_base.sqlite | v1 | 2026-04-21T18:38:39.274925 | First commit of the 26-zone, 20-week US Power System Model (No server demands) | [Download](https://data.openenergyoutlook.org/usp_26z_base/v1-7b8bfa0e3a3dfd5a3f7341f9448869d3b4295107a19efe3e6fb5eda9aa46ecdf.sqlite) |
 | usp_26z_serverdemand.sqlite | v1 | 2026-04-21T18:43:04.658352 | First commit of the 26-zone, 20-week US Power System Model with server demands | [Download](https://data.openenergyoutlook.org/usp_26z_serverdemand/v1-76be29acb9ad80cbe353797b5087d40db2f43cff44584add2e65ae0645963b95.sqlite) |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed older versions (v4, v3, v2) of the test_database.sqlite dataset from the published datasets list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->