### PR TITLE
Add oeo_9r_8d_base v1: canonical US 9-region v4 OEO input DB

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -66,5 +66,22 @@
         "description": "First commit of the 26-zone, 20-week US Power System Model (No server demands)"
       }
     ]
+  },
+  {
+    "fileName": "oeo_9r_8d_base.sqlite",
+    "latestVersion": "v1",
+    "history": [
+      {
+        "version": "v1",
+        "timestamp": "2026-07-16T12:28:03.466538Z",
+        "sha256": "82c325ac430c9678599a438b147ed9cf1c7e4ea0af1f9a9aef282ee981db3b59",
+        "r2_object_key": "oeo_9r_8d_base/v1-82c325ac430c9678599a438b147ed9cf1c7e4ea0af1f9a9aef282ee981db3b59.sqlite",
+        "staging_key": "staging-uploads/82c325ac430c9678599a438b147ed9cf1c7e4ea0af1f9a9aef282ee981db3b59.sqlite",
+        "diffFromPrevious": null,
+        "commit": "pending-merge",
+        "temoaRepoHash": "9d26bd57b81abec5c2632ba2a9d591d91472a99a",
+        "description": "pending-merge"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Adds **oeo_9r_8d_base v1** — the US 9-region, 8-day Temoa v4 input database produced by the v3→v4 migration.

- sha256: `44b6f7dd74a2484c0cddf3d2b57ad563f1fe321a2c41f5f1882418f18f5fbd86` (uploaded to staging)
- Solves on **TemoaProject/temoa `9d26bd57`** (`unstable`, 2026-07-10) — verified by a full 9-region myopic solve (Gurobi, 7 windows) reproducing the v3-Cost-Paper-validated results.
- **Install note:** use `pyomo<6.10` — pyomo 6.10.x has a `sparse_keys` performance regression (~200× slower model builds at this scale; fix pending in Pyomo/pyomo#3971).
- Input-only: all output tables empty.
- Validated end-to-end against the v3 Cost Paper at $0 and $400/t CO₂; full change ledger (migration fixes, v3.1 source-data errata repairs, model updates) lives in the migration repo's CHANGELOG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manifest tracking for the `oeo_9r_8d_base.sqlite` release.
  * Recorded version 1 metadata, including integrity details and release history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->